### PR TITLE
Enable building on OCaml 5.3

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -13,7 +13,7 @@
  (synopsis "Streaming client for Memprof using MirageOS API")
  (description "Generates compact traces of a program's memory use.")
  (depends
-  (ocaml (and (>= 4.11.0) (< 5)))
+  (ocaml (or (and (>= 4.11.0) (< 5)) (>= 5.3.0)))
   (mirage-flow (>= 3.0.0))
   (mirage-ptime (>= 5.0.0))
   (ptime (>= 1.0.0))

--- a/memtrace-mirage.opam
+++ b/memtrace-mirage.opam
@@ -13,14 +13,14 @@ homepage: "https://github.com/robur-coop/memtrace-mirage"
 bug-reports: "https://github.com/robur-coop/memtrace-mirage/issues"
 depends: [
   "dune" {>= "2.3"}
-  "ocaml" {>= "4.11.0" & < "5"}
+  "ocaml" {>= "4.11.0" & < "5" | >= "5.3.0"}
   "mirage-flow" {>= "3.0.0"}
   "mirage-ptime" {>= "5.0.0"}
   "ptime" {>= "1.0.0"}
   "lwt" {>= "5.5.0"}
 ]
 build: [
-  ["dune" "subst"] {dev}
+  ["dune" "subst"] {pinned}
   [
     "dune"
     "build"

--- a/src/trace.ml
+++ b/src/trace.ml
@@ -352,9 +352,10 @@ let make_writer dest ?getpid (info : Info.t) =
 
 module IntTbl = Hashtbl.MakeSeeded (struct
   type t = int
-  let hash _seed (id : t) =
+  let seeded_hash _seed (id : t) =
     let h = id * 189696287 in
     h lxor (h lsr 23)
+  let hash = seeded_hash
   let equal (a : t) (b : t) = a = b
 end)
 


### PR DESCRIPTION
Tested that mirage-monitoring builds on OCaml 5.3.